### PR TITLE
Clarifies exerciseDescription command in CMPE sample

### DIFF
--- a/docs/CMPE_sample.tex
+++ b/docs/CMPE_sample.tex
@@ -14,7 +14,7 @@
 \newcommand{\LectureSectionNum}{For the lecture}
 \newcommand{\LectureInstructor}{Mr.\ Lecturer}
 \newcommand{\exerciseNumber}{1}
-\newcommand{\exerciseDescription}{Put the description from the lab manual here}
+\newcommand{\exerciseDescription}{Put the title of the lab manual here. This is different from the objective. }
 \newcommand{\dateDone}{Date of lab}
 \newcommand{\dateSubmitted}{Date due by}
 


### PR DESCRIPTION
I got points off for putting the objective of the lab in the `exerciseDescription` field, when this should actually be the title of the lab, and not the objective. Just wanted to make it more clear.